### PR TITLE
chore(changelog): set message for releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+The changelog is automatically updated using
+[semantic-release](https://github.com/semantic-release/semantic-release). You
+can see it on the [releases page](../../releases).


### PR DESCRIPTION
is not needed to generate on top of CHANGELOG since it's been handled by semantic-release

closes #39